### PR TITLE
Added submit action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Actions
+
+This repository defines some shared [GitHub
+Actions](https://docs.github.com/en/actions).
+
+## Submit Action
+
+This action is defined in the [submit/action.yml](./submit/action.yml) file. It
+checks out the Git sources and submits the package to OBS Factory by running the
+`rake osc:sr` command.
+
+The default rake task can be changed to `osc:commit` if the package should be
+only uploaded to YaST:Head but not submitted to OBS Factory. See the example
+below.
+
+If the last commit belongs to a pull request then a comment with the action
+result is added there.
+
+See more details in the
+[packaging_rake_tasks](https://github.com/openSUSE/packaging_rake_tasks)
+repository.
+
+### Example
+
+Upload the package to YaST:Head and create a submit to OBS Factory:
+
+```yml
+steps:
+  - name: Submit the package to OBS Factory
+    uses: yast/actions/submit@master
+    with:
+      obs_user:     ${{ secrets.OBS_USER }}
+      obs_password: ${{ secrets.OBS_PASSWORD }}
+```
+
+Only upload the package to YaST:Head without a submit request to OBS Factory:
+
+```yml
+steps:
+  - name: Commit the package to YaST:Head
+    uses: yast/actions/submit@master
+    with:
+      obs_user:     ${{ secrets.OBS_USER }}
+      obs_password: ${{ secrets.OBS_PASSWORD }}
+      task:         osc:commit
+```

--- a/submit/action.yml
+++ b/submit/action.yml
@@ -1,0 +1,110 @@
+# See https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
+
+name: OBS Submission
+description: Submit the sources by running the "osc:sr" YaST Rake task
+
+inputs:
+  task:
+    # allow changing the default rake task, some packages are only
+    # comitted to YaST:Head project without submitting to openSUSE Factory,
+    # use "osc:commit" in that case
+    description: Rake task to run
+    default: osc:sr
+
+  obs_user:
+    description: OBS user name
+    required: true
+
+  obs_password:
+    description: OBS password
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Git Checkout
+      uses: actions/checkout@v4
+
+    - name: Start the YaST container
+      shell: bash
+      run: sudo podman run --privileged --detach --name yast -e CI -e GITHUB_ACTIONS
+        -v ${{ github.action_path }}:/action -v .:/checkout -w /checkout
+        registry.opensuse.org/yast/head/containers_tumbleweed/yast-rake:latest
+        tail -f /dev/null
+
+    - name: Fix permissions to avoid git failures
+      shell: bash
+      run: sudo podman exec yast chown -R 0 .
+
+    - name: Configure osc
+      shell: bash
+      run: sudo --preserve-env=OBS_USER,OBS_PASSWORD podman exec -e OBS_USER -e OBS_PASSWORD yast /action/src/configure_osc.sh
+      env:
+        OBS_USER: ${{ inputs.obs_user }}
+        OBS_PASSWORD: ${{ inputs.obs_password }}
+
+    - name: Run rake
+      shell: bash
+      id: rake
+      run: |
+        OUTFILE=$(mktemp -p '' yast_rake_XXXXXXX)
+        sudo podman exec --privileged yast rake ${{ inputs.task }} | tee $OUTFILE
+        SR=$((grep "^created request id [0-9]+" $OUTFILE || true) | sed -e 's/created request id //')
+        # pass the SR number
+        echo "submit=$SR" >> $GITHUB_OUTPUT
+        rm $OUTFILE
+
+    - name: Success status comment
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        SUBMIT:   ${{ steps.rake.outputs.submit }}
+      # find the pull request for this git checkout and add a comment with submission details
+      run: |
+        PR=$(gh pr list --state merged --search ${{ github.sha }} --json number --jq '.[0].number')
+
+        if [ -n "$PR" ]; then
+          echo "Found pull request $PR (${{ github.server_url }}/${{ github.repository }}/pull/$PR)"
+          JOB_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG=":white_check_mark: Autosubmission job [#${{ github.run_id }}]($JOB_URL) successfully finished"
+
+          if echo "$SUBMIT" | grep -q "^[0-9]\+$"; then
+            SR_URL="https://build.opensuse.org/request/show/$SUBMIT"
+            echo "Created submit request $SUBMIT ($SR_URL)"
+            MSG="$MSG
+        :white_check_mark: Created submit request [#$SUBMIT]($SR_URL)"
+          fi
+
+          gh issue comment $PR --body "$MSG"
+        else
+          echo "Pull request not found, skipping status comment"
+        fi
+
+    - name: Failed status comment
+      shell: bash
+      # not succeeded (failed, aborted, ...)
+      if: ${{ !success() }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+      # find the pull request for this git checkout and add a comment with failure details
+      run: |
+        PR=$(gh pr list --state merged --search ${{ github.sha }} --json number --jq '.[0].number')
+
+        if [ -n "$PR" ]; then
+          echo "Found pull request $PR (${{ github.server_url }}/${{ github.repository }}/pull/$PR)"
+          JOB_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG=":x: Autosubmission job [#${{ github.run_id }}]($JOB_URL) failed"
+          gh issue comment $PR --body "$MSG"
+        else
+          echo "Pull request not found, skipping status comment"
+        fi
+
+    - name: Stop the YaST container
+      shell: bash
+      run: sudo podman stop yast
+
+    # the checkout action does some cleanup at the end, restore the original permissions
+    - name: Restore permissions
+      shell: bash
+      run: sudo chown -R runner:docker .

--- a/submit/src/configure_osc.sh
+++ b/submit/src/configure_osc.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+# This helper script creates the "osc" configuration file with OBS credentials
+
+CONFIG_FILE="$HOME/.config/osc/oscrc"
+
+# do not overwrite the existing config accidentally
+if [ -e "$CONFIG_FILE" ]; then
+  echo "$CONFIG_FILE already exists"
+  exit 0
+fi
+
+TEMPLATE=$(dirname "${BASH_SOURCE[0]}")/oscrc.template
+mkdir -p $(dirname "$CONFIG_FILE")
+sed -e "s/@OBS_USER@/$OBS_USER/g" -e "s/@OBS_PASSWORD@/$OBS_PASSWORD/g" "$TEMPLATE" > "$CONFIG_FILE"
+
+echo "Created $CONFIG_FILE"

--- a/submit/src/oscrc.template
+++ b/submit/src/oscrc.template
@@ -1,0 +1,8 @@
+[general]
+apiurl = https://api.opensuse.org
+
+[https://api.opensuse.org]
+user=@OBS_USER@
+pass=@OBS_PASSWORD@
+credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
+trusted_prj=YaST:Head openSUSE:Factory


### PR DESCRIPTION
## Problem

- Replace Jenkins autosubmission to OBS Factory by a GitHub Action
  - Less maintenance, everything at one place

## Solution

- Define a shared GitHub action so we can easily use it from all YaST packages
- See [example usage in a yast-devtools fork](https://github.com/lslezak/yast-devtools/blob/master/.github/workflows/submit.yml)

## Testing

- Tested manually
- [Example run](https://github.com/lslezak/yast-devtools/actions/runs/7756222919/job/21153113170) (it used just `rake osc:config` to not submit the package for real)
- [Example comment in a pull request](https://github.com/lslezak/yast-devtools/pull/5)
