### PR TITLE
Set UTF-8 locale

### DIFF
--- a/submit/action.yml
+++ b/submit/action.yml
@@ -29,6 +29,7 @@ runs:
     - name: Start the YaST container
       shell: bash
       run: sudo podman run --privileged --detach --name yast -e CI -e GITHUB_ACTIONS
+        -e LC_ALL=en_US.UTF-8 -e LANG=en_US.UTF-8
         -v ${{ github.action_path }}:/action -v .:/checkout -w /checkout
         registry.opensuse.org/yast/head/containers_tumbleweed/yast-rake:latest
         tail -f /dev/null


### PR DESCRIPTION
## Problem

The autosubmission fails with this error:
```
ArgumentError: invalid byte sequence in US-ASCII (ArgumentError)
```
See https://github.com/yast/yast-installation/actions/runs/7803425666/job/21283168873#step:2:143

Probably caused by not set UTF-8 locale.

## Solution

Explicitly set the UTF-8 locale.

