### PR TITLE
Fixed SR regexp

### DIFF
--- a/submit/action.yml
+++ b/submit/action.yml
@@ -50,7 +50,7 @@ runs:
       run: |
         OUTFILE=$(mktemp -p '' yast_rake_XXXXXXX)
         sudo podman exec --privileged yast rake ${{ inputs.task }} | tee $OUTFILE
-        SR=$((grep "^created request id [0-9]+" $OUTFILE || true) | sed -e 's/created request id //')
+        SR=$((grep "^created request id [0-9]\+" $OUTFILE || true) | sed -e 's/created request id //')
         # pass the SR number
         echo "submit=$SR" >> $GITHUB_OUTPUT
         rm $OUTFILE
@@ -102,9 +102,12 @@ runs:
 
     - name: Stop the YaST container
       shell: bash
-      run: sudo podman stop yast
+      run: |
+        sudo podman stop yast
+        sudo podman rm yast
 
     # the checkout action does some cleanup at the end, restore the original permissions
     - name: Restore permissions
+      if: ${{ always() }}
       shell: bash
       run: sudo chown -R runner:docker .


### PR DESCRIPTION
## Problem

- The regexp for finding the SR number in the OSC output was wrong, there was a missing escape.

## Solution

- Added missing escape

## Additional Improvements

- Remove the container at the end. (Not strictly required at GitHub because it runs in a VM which is discarded when finished, but if you want to reproduce the same steps locally you will get a hanging container. If you try the same steps again you will get an error because the container already exists.)
- Always restore the permissions at the end. (When the action fails the changed permissions would result in an error in the cleanup step at the end, see https://github.com/yast/yast-installation/actions/runs/7803425666)