### PR TITLE
Allow running a custom command

### DIFF
--- a/submit/action.yml
+++ b/submit/action.yml
@@ -11,6 +11,13 @@ inputs:
     description: Rake task to run
     default: osc:sr
 
+  command:
+    # allow running arbitrary command instead of `rake`, useful for multi build
+    # packages to build all package flavors before submission,
+    # example: "rake 'osc:build[-M default]' && rake 'osc:build[-M micro]' && rake osc:sr"
+    description: Custom command to run (the default is 'rake')
+    default: ""
+
   obs_user:
     description: OBS user name
     required: true
@@ -48,8 +55,13 @@ runs:
       shell: bash
       id: rake
       run: |
+        CMD="${{ inputs.command }}"
+        if [ -z "$CMD" ]; then
+          CMD="rake '${{ inputs.task }}'"
+        fi
+
         OUTFILE=$(mktemp -p '' yast_rake_XXXXXXX)
-        sudo podman exec --privileged yast rake ${{ inputs.task }} | tee $OUTFILE
+        sudo podman exec --privileged yast bash -c "$CMD" | tee $OUTFILE
         SR=$((grep "^created request id [0-9]\+" $OUTFILE || true) | sed -e 's/created request id //')
         # pass the SR number
         echo "submit=$SR" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

- For the yast2-schema package we run the `rake 'osc:build[-M default]' && rake 'osc:build[-M micro]' && rake osc:sr` command in Jenkins.
- This builds all multibuild packages before submitting to Factory
- That's not possible with the current action

## Solution

- Allow passing an arbitrary command to the GitHub Action to run instead of the default `rake` command


## Testing

- Tested manually, see [example run](https://github.com/lslezak/yast-schema/actions/runs/10246713215/job/28344400160) in my fork which correctly built both packages (yast2-schema-default and yast2-schema-micro)
