### PR TITLE
Mark openSUSE:Tumbleweed as trusted project

### DIFF
--- a/submit/src/oscrc.template
+++ b/submit/src/oscrc.template
@@ -5,4 +5,4 @@ apiurl = https://api.opensuse.org
 user=@OBS_USER@
 pass=@OBS_PASSWORD@
 credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
-trusted_prj=YaST:Head openSUSE:Factory
+trusted_prj=YaST:Head openSUSE:Factory openSUSE:Tumbleweed


### PR DESCRIPTION
## Problem

- Submitting the YaST containers fails with this error:
```
The build root needs packages from project 'openSUSE:Tumbleweed'.
Note that malicious packages can compromise the build result or even your system.
Would you like to ...
0 - quit (default)
1 - always trust packages from 'openSUSE:Tumbleweed'
2 - trust packages just this time
? Well, goodbye then :-)
rake aborted!
```

## Solution

- Trust the `openSUSE:Tumbleweed` project as well

