### PR TITLE
Set `CI=true` in the container

### DIFF
--- a/submit/action.yml
+++ b/submit/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - name: Start the YaST container
       shell: bash
-      run: sudo podman run --privileged --detach --name yast -e CI -e GITHUB_ACTIONS
+      run: sudo podman run --privileged --detach --name yast
         -v ${{ github.action_path }}:/action -v .:/checkout -w /checkout
         registry.opensuse.org/yast/head/containers_tumbleweed/yast-rake:latest
         tail -f /dev/null
@@ -61,7 +61,7 @@ runs:
         fi
 
         OUTFILE=$(mktemp -p '' yast_rake_XXXXXXX)
-        sudo podman exec --privileged yast bash -c "$CMD" | tee $OUTFILE
+        sudo podman exec --privileged -e CI=true yast bash -c "$CMD" | tee $OUTFILE
         SR=$((grep "^created request id [0-9]\+" $OUTFILE || true) | sed -e 's/created request id //')
         # pass the SR number
         echo "submit=$SR" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

- Unfortunately the fix https://github.com/yast/ci-ruby-container/pull/24 is not enough
- The `CI` environment variable is not set in the container
- Probably the environment variables are not passed to a shared action for security reasons

## Solution

- Explicitly set `CI=true` for the executed command in the container

## Notes

- The `-e CI` option means set the `CI` variable in the container to the current value. But as the variable is not defined in the current process then it is also not defined in the container.
- On the other hand `-e CI=true` means set `CI` to `true` in the container unconditionally

## Testing

- Tested manually in my fork
